### PR TITLE
attempt to print stack trace addresses

### DIFF
--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -9,6 +9,7 @@ const ArrayList = std.ArrayList;
 const builtin = @import("builtin");
 
 const execinfo = @cImport(@cInclude("execinfo.h"));
+const printf = @cImport(@cInclude("stdio.h")).printf;
 
 pub const FailingAllocator = @import("failing_allocator.zig").FailingAllocator;
 
@@ -263,7 +264,7 @@ pub fn openSelfDebugInfo(allocator: &mem.Allocator) !&ElfStackTrace {
 
             var i:i32 = 0;
             while (i < frames):(i += 1) {
-                warn("{}\n", (??strs)[usize(i)]);
+                _ = printf(c"%s\n", ??(??strs)[usize(i)]);
             }
             return error.TodoSupportMachoDebugInfo;
         },

--- a/std/debug/index.zig
+++ b/std/debug/index.zig
@@ -263,7 +263,7 @@ pub fn openSelfDebugInfo(allocator: &mem.Allocator) !&ElfStackTrace {
 
             var i:i32 = 0;
             while (i < frames):(i += 1) {
-                warn("{}\n", strs);
+                warn("{}\n", (??strs)[usize(i)]);
             }
             return error.TodoSupportMachoDebugInfo;
         },


### PR DESCRIPTION
I'm just experimenting, but I'm at

https://www.unix.com/man-page/osx/3/backtrace/
and
https://searchfox.org/mozilla-central/source/widget/cocoa/nsCocoaDebugUtils.h#11
and
https://github.com/rust-lang/rust/issues/24346